### PR TITLE
Handle Dict as relationship

### DIFF
--- a/exonetapi/result/Resource.py
+++ b/exonetapi/result/Resource.py
@@ -109,7 +109,9 @@ class Resource:
                     relation_list.append(relation_resource.to_json_resource_identifier())
                 relationships[relation_name] = {}
                 relationships[relation_name]['data'] = relation_list
-
+            elif type(relation) is dict:
+                relationships[relation_name] = {}
+                relationships[relation_name]['data'] = relation['data']
             else:
                 relationships[relation_name] = {}
                 relationships[relation_name]['data'] = relation.to_json_resource_identifier()

--- a/exonetapi/result/Resource.py
+++ b/exonetapi/result/Resource.py
@@ -103,17 +103,15 @@ class Resource:
         relationships = {}
 
         for relation_name, relation in self.__relationships.items():
+            relationships[relation_name] = {}
             if type(relation) is list:
                 relation_list = []
                 for relation_resource in relation:
                     relation_list.append(relation_resource.to_json_resource_identifier())
-                relationships[relation_name] = {}
                 relationships[relation_name]['data'] = relation_list
             elif type(relation) is dict:
-                relationships[relation_name] = {}
                 relationships[relation_name]['data'] = relation['data']
             else:
-                relationships[relation_name] = {}
                 relationships[relation_name]['data'] = relation.to_json_resource_identifier()
 
         return relationships

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='exonetapi',
-    version='0.0.1',
+    version='0.0.2',
 
     description='Library to interact with the Exonet API.',
     long_description=long_description,

--- a/tests/result/testResource.py
+++ b/tests/result/testResource.py
@@ -107,6 +107,33 @@ class testResource(unittest.TestCase):
             })
         )
 
+    def test_get_json_relationships(self):
+        resource = create_resource.create_resource(
+            'fake',
+            relationships={
+                'thing': {
+                    'data' : {
+                        'type': 'things',
+                        'id' : 'thingID'
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(
+            json.dumps(resource.get_json_relationships()),
+            json.dumps(
+                {
+                    'thing': {
+                        'data': {
+                            'type': 'things',
+                            'id': 'thingID'
+                        }
+                    }
+                }
+            )
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When parsing a json response from the API, the relationships are defined as object/dict. These relations can now be parsed.