### PR TITLE
Use instance variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 [Compare 0.0.2 - Unreleased](https://github.com/exonet/exonet-api-python/compare/0.0.2...master)
+### Changed
+- Most class variables changed to instance variables.
+  This enforces the defaults to be set, instead of using the same variables from another instance.
 
 ## [0.0.2](https://github.com/exonet/exonet-api-python/releases/tag/0.0.2) - 2018-05-23
 [Compare 0.0.1 - 0.0.2](https://github.com/exonet/exonet-api-python/compare/0.0.1...0.0.2)

--- a/exonetapi/RequestBuilder.py
+++ b/exonetapi/RequestBuilder.py
@@ -17,18 +17,19 @@ class RequestBuilder:
     __host = None
     # An Authenticator instance to use when making requests to the API.
     __authenticator = None
-    # The resource name to access.
-    __resource_name = None
-    # Optional resource ID.
-    __id = None
-    # Optional related resources name.
-    __related = None
-    # The query params that will be used in the GET requests. Can contain filters and page options.
-    __query_params = {}
 
     def __init__(self, host, authenticator):
         self.__host = host
         self.__authenticator = authenticator
+
+        # The resource name to access.
+        self.__resource_name = None
+        # Optional resource ID.
+        self.__id = None
+        # Optional related resources name.
+        self.__related = None
+        # The query params that will be used in the GET requests. Can contain filters and page options.
+        self.__query_params = {}
 
     def set_resource(self, resource_name):
         """Prepare this RequestBuilder to query a specific resource.

--- a/exonetapi/result/Parser.py
+++ b/exonetapi/result/Parser.py
@@ -9,10 +9,6 @@ class Parser:
     """Parse API responses into Resources.
     Accepts JSON strings in the JSON-API format.
     """
-    # The plain JSON as a string.
-    __data = None
-    # The parsed JSON data as a dict.
-    __json_data = None
 
     def __init__(self, data):
         self.__data = data

--- a/exonetapi/result/Resource.py
+++ b/exonetapi/result/Resource.py
@@ -7,23 +7,20 @@ from inflection import underscore
 class Resource:
     """Basic Resource with attributes.
     """
-    # Keep track of the resource type.
-    __type = None
-    # Keep track of the resource id.
-    __id = None
-    # The Resource attributes.
-    __attributes = {}
-
-    # The relationships for this resource.
-    __relationships = {}
 
     def __init__(self, attributes, id=None, relationships=None):
+        # Keep track of the resource type.
         self.__type = underscore(self.__class__.__name__)
+        # The Resource attributes.
         self.__attributes = attributes
+        # Keep track of the resource id.
         self.__id = id
 
+        # The relationships for this resource.
         if relationships:
             self.__relationships = relationships
+        else :
+            self.__relationships = {}
 
     def attribute(self, item):
         """Get Resource attributes if available.


### PR DESCRIPTION
## What? 🤷🏼‍♀️
When making multiple calls to different resources, new instances of `RequestBuilder` are created. Before using instance variables they shared some variables. For example, setting a size-limit on the first request, would result in the second request to have the same limit (when not explicitly set again).

### Test example
```python
# Make a call to the `/tickets` endpoint with a query string page size of 1.
oneTicket = client.resource('tickets').size(1).get()[0]

# Make a call to the `/certificates` endpoint. Without any query params.
allCertificates = client.resource('certificates').get()

# Show how many certificates were returned.
print(len(allCertificates))
```

**Before:**
The output would be `1` since the call to the certificates endpoint had `?page[size]=1` applied because it was set during the ticket request.
**After:**
The output now shows the actual number of certificates. The url that is used is `/certificates`, no query string.