### PR TITLE
Relation getter and setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## Unreleased
 [Compare 0.0.2 - Unreleased](https://github.com/exonet/exonet-api-python/compare/0.0.2...master)
+### Added
+- Individual methods to set or get relationships from a resource object.
+
 ### Changed
 - Most class variables changed to instance variables.
   This enforces the defaults to be set, instead of using the same variables from another instance.

--- a/exonetapi/result/Resource.py
+++ b/exonetapi/result/Resource.py
@@ -50,7 +50,32 @@ class Resource:
         """
         return self.__id
 
-    def relationship(self, name, data):
+    def relationship(self, name, *data):
+        """Define a new relationship for this resource, replace an existing one or get an existing one.
+        When data is provided the relationship is set, without data the relationship is returned.
+
+        :param name: The name of the relation to set.
+        :param data: The value of the relation, can be a Resource or a dict of Resources.
+        :return: self when setting a relationship, or the actual relationship when getting it
+        """
+        if len(data) is 1:
+            return self.set_relationship(name, data[0])
+
+        return self.get_relationship(name)
+
+    def get_relationship(self, name):
+        """Get a relationship for this resource.
+
+        :param name: The name of the relation to get.
+        :return: The defined relation or None
+        """
+
+        if name in self.__relationships:
+            return self.__relationships[name]
+
+        return None
+
+    def set_relationship(self, name, data):
         """Define a new relationship for this resource or replace an existing one.
         Can be a relation to a single Resource or a dict of Resources.
 

--- a/tests/result/testResource.py
+++ b/tests/result/testResource.py
@@ -134,6 +134,60 @@ class testResource(unittest.TestCase):
             )
         )
 
+    def test_get_relationship_single(self):
+        resource = create_resource.create_resource('fake')
+        resource.set_relationship(
+            'thing',
+            create_resource.create_resource('things', id='thingID')
+        )
+
+        self.assertEqual(
+            resource.get_relationship('thing').to_json_resource_identifier(),
+            {
+                'type': 'things',
+                'id': 'thingID'
+            }
+        )
+
+    def test_get_relationship_multi(self):
+        resource = create_resource.create_resource('fake')
+        resource.set_relationship(
+            'thingies',
+            [
+                create_resource.create_resource('things', id='thingOneID'),
+                create_resource.create_resource('things', id='thingTwoID')
+            ]
+        )
+
+        relations = resource.get_relationship('thingies')
+
+        relationlist = []
+        for relation in relations:
+            relationlist.append(relation.to_json_resource_identifier())
+
+
+        self.assertEqual(
+            relationlist,
+            [
+                {
+                    'type': 'things',
+                    'id': 'thingOneID'
+                },
+                {
+                    'type': 'things',
+                    'id': 'thingTwoID'
+                }
+            ]
+        )
+
+    def test_relationship_none(self):
+        resource = create_resource.create_resource('dummy')
+
+        self.assertEqual(
+            resource.relationship('invalid'),
+            None
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What? 🐙
Added individual getter and setter method for relationships. Can be used to get the relations from a resource that came back from the API.

The existing `relationship` method is kept to maintain backwards compatibility