### PR TITLE
Add support for PATCH and DELETE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 [Compare 1.0.0 - Unreleased](https://github.com/exonet/exonet-api-python/compare/1.0.0...master)
+### Added
+- Support for `PATCH` and `DELETE` requests.
+
+### Deprecated
+- The `store` method for creating `POST` requests is now deprecated. Use `post` instead.
 
 ## [1.0.0](https://github.com/exonet/exonet-api-python/releases/tag/1.0.0) - 2019-08-14
 [Compare 0.0.5 - 1.0.0](https://github.com/exonet/exonet-api-python/compare/0.0.5...1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 [Compare 1.0.0 - Unreleased](https://github.com/exonet/exonet-api-python/compare/1.0.0...master)
+### Breaking
+- The `Api` prefix has been added from the following classes for consistency:
+  - `Resource` --> `ApiResource`
+  - `ResourceIdentifier` --> `ApiResourceIdentifier`
+  
 ### Added
 - Support for `PATCH` and `DELETE` requests.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,5 +3,6 @@
 - [Using this package](using.md)
 - [Making API calls](calls.md)
 - [Responses](responses.md)
+- [Resources](resources.md)
 - [Error handling](error_handling.md)
   

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -24,7 +24,7 @@ record.attribute('type', 'A')
 record.attribute('content', '192.168.1.100')
 record.attribute('ttl', 3600)
 # The value of a relationship must be defined as a resource identifier.
-record.relationship('zone', ResourceIdentifier('dns_zones', 'VX09kwR3KxNo'))
+record.relationship('zone', ApiResourceIdentifier('dns_zones', 'VX09kwR3KxNo'))
 result = record.post()
 print(result)
 ```
@@ -35,13 +35,13 @@ Modify a resource by changing its attributes and/or relationships:
 ```python
 dns_record = client.resource('dns_records').get('VX09kwR3KxNo')
 # Or, if there is no need to retrieve the resource from the API first you can use the following:
-# dns_record = Resource('dns_records', 'VX09kwR3KxNo')
+# dns_record = ApiResource('dns_records', 'VX09kwR3KxNo')
 
 # Change the 'name' attribute to 'changed-name'.
 dns_record.attribute('name', 'changed-name')
 
 # The value of a relationship must be defined as a resource identifier.
-dns_record.relationship('dns_zone', ResourceIdentifier('dns_zones', 'X09kwRdbbAxN'))
+dns_record.relationship('dns_zone', ApiResourceIdentifier('dns_zones', 'X09kwRdbbAxN'))
 
 # Patch the changed data to the API.
 dns_record.patch()
@@ -53,7 +53,7 @@ Delete a resource with a given ID:
 ```python
 dns_record = client.resource('dns_records').get('VX09kwR3KxNo')
 # Or, if there is no need to retrieve the resource from the API first you can use the following:
-# dns_record = Resource('dns_records', 'VX09kwR3KxNo')
+# dns_record = ApiResource('dns_records', 'VX09kwR3KxNo')
 
 dns_record.delete()
 ```

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -23,8 +23,8 @@ record.attribute('name', 'www')
 record.attribute('type', 'A')
 record.attribute('content', '192.168.1.100')
 record.attribute('ttl', 3600)
-# The value of a relationship must be defined as a resource.
-record.relationship('zone', Resource('dns_zones', 'VX09kwR3KxNo'))
+# The value of a relationship must be defined as a resource identifier.
+record.relationship('zone', ResourceIdentifier('dns_zones', 'VX09kwR3KxNo'))
 result = record.store()
 print(result)
 ```
@@ -40,8 +40,8 @@ dns_record = client.resource('dns_records').get('VX09kwR3KxNo')
 # Change the 'name' attribute to 'changed-name'.
 dns_record.attribute('name', 'changed-name')
 
-# The value of a relationship must be defined as a resource.
-dns_record.relationship('dns_zone', Resource('dns_zones', 'X09kwRdbbAxN'))
+# The value of a relationship must be defined as a resource identifier.
+dns_record.relationship('dns_zone', ResourceIdentifier('dns_zones', 'X09kwRdbbAxN'))
 
 # Patch the changed data to the API.
 dns_record.patch()

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,59 @@
+# Resources
+
+## Getting data from a resource
+Get data from the attributes or relationships of a resource. See [making API calls](calls.md) for more information on 
+how to get resources from the API.
+
+```python
+dns_record = client.resource('dns_records').get('VX09kwR3KxNo')
+
+# Show an attribute value:
+print(dns_record.attribute('name'))
+
+# Get a related value, in this case the name of the DNS zone:
+print(dns_record.related('zone').get().attribute('name'))
+```
+
+## Creating a new resource
+Store a new resource to the API by setting its attributes and relationships:
+
+```python
+record = Resource('dns_records')
+record.attribute('name', 'www')
+record.attribute('type', 'A')
+record.attribute('content', '192.168.1.100')
+record.attribute('ttl', 3600)
+# The value of a relationship must be defined as a resource.
+record.relationship('zone', Resource('dns_zones', 'VX09kwR3KxNo'))
+result = record.store()
+print(result)
+```
+
+## Modifying a resource
+Modify a resource by changing its attributes and/or relationships:
+
+```python
+dns_record = client.resource('dns_records').get('VX09kwR3KxNo')
+# Or, if there is no need to retrieve the resource from the API first you can use the following:
+# dns_record = Resource('dns_records', 'VX09kwR3KxNo')
+
+# Change the 'name' attribute to 'changed-name'.
+dns_record.attribute('name', 'changed-name')
+
+# The value of a relationship must be defined as a resource.
+dns_record.relationship('dns_zone', Resource('dns_zones', 'X09kwRdbbAxN'))
+
+# Patch the changed data to the API.
+dns_record.patch()
+``` 
+
+## Deleting a resource
+Delete a resource with a given ID:
+
+```python
+dns_record = client.resource('dns_records').get('VX09kwR3KxNo')
+# Or, if there is no need to retrieve the resource from the API first you can use the following:
+# dns_record = Resource('dns_records', 'VX09kwR3KxNo')
+
+dns_record.delete()
+```

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -15,7 +15,7 @@ print(dns_record.related('zone').get().attribute('name'))
 ```
 
 ## Creating a new resource
-Store a new resource to the API by setting its attributes and relationships:
+Post a new resource to the API by setting its attributes and relationships:
 
 ```python
 record = Resource('dns_records')
@@ -25,7 +25,7 @@ record.attribute('content', '192.168.1.100')
 record.attribute('ttl', 3600)
 # The value of a relationship must be defined as a resource identifier.
 record.relationship('zone', ResourceIdentifier('dns_zones', 'VX09kwR3KxNo'))
-result = record.store()
+result = record.post()
 print(result)
 ```
 

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -1,9 +1,9 @@
 # Working with API Responses
-There are two types of API responses upon a successful request. If a single resource is requested then a `Resource` instance is
+There are two types of API responses upon a successful request. If a single resource is requested then a [`Resource`](resources.md) instance is
 returned, if multiple resources are requested then an `list` of `Resource`'s is returned.
 
-## The `Resource` class
-Each resource returned by the API is transformed to an `Resource` instance. This makes it possible to have easy access
+## The [`Resource`](resources.md) class
+Each resource returned by the API is transformed to an [`Resource`](resources.md) instance. This makes it possible to have easy access
 to the attributes, type and ID of the resource.
 
 ```python
@@ -28,7 +28,7 @@ This list contains the requested resources. Iterate over the list to handle the 
 ```python
 
 # Get all certificates
-certificates = CLIENT.resource('certificates').size(10).get()
+certificates = client.resource('certificates').size(10).get()
 
 for certificate in certificates:
     print(

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -1,9 +1,9 @@
 # Working with API Responses
-There are two types of API responses upon a successful request. If a single resource is requested then a [`Resource`](resources.md) instance is
-returned, if multiple resources are requested then an `list` of `Resource`'s is returned.
+There are two types of API responses upon a successful request. If a single resource is requested then a [`ApiResource`](resources.md) instance is
+returned, if multiple resources are requested then an `list` of `ApiResource`'s is returned.
 
-## The [`Resource`](resources.md) class
-Each resource returned by the API is transformed to an [`Resource`](resources.md) instance. This makes it possible to have easy access
+## The [`ApiResource`](resources.md) class
+Each resource returned by the API is transformed to an [`ApiResource`](resources.md) instance. This makes it possible to have easy access
 to the attributes, type and ID of the resource.
 
 ```python

--- a/examples/new_dns_zones.py
+++ b/examples/new_dns_zones.py
@@ -1,15 +1,14 @@
 # Run this script using: python examples/dns_zones.py <YOUR-TOKEN>
 import sys
 from exonetapi import Client
-from dev import DevHelper
+from exonetapi.structures import ResourceIdentifier
 from exonetapi.structures import Resource
 
 # Create a new Client.
 client = Client()
 
 # Authorize with a personal access token.
-# client.authenticator.set_token(sys.argv[1])
-client.authenticator.set_token(DevHelper.token)
+client.authenticator.set_token(sys.argv[1])
 
 print('\nAdd a new DNS zone\n')
 
@@ -18,7 +17,7 @@ zone = Resource('dns_zones')
 zone.attribute('name', 'my-new-zone.com')
 zone.attribute('dnssec', True)
 # Replace the customer ID with your own customer ID.
-zone.relationship('customer', Resource('customers', 'X09kwRdbbAxN'))
+zone.relationship('customer', ResourceIdentifier('customers', 'X09kwRdbbAxN'))
 # Send the new resource to the API.
 zone_result = zone.store()
 
@@ -28,7 +27,7 @@ record1.attribute('name', 'www')
 record1.attribute('type', 'A')
 record1.attribute('content', '192.168.1.100')
 record1.attribute('ttl', 3600)
-record1.relationship('zone', Resource('dns_zones', zone_result.id()))
+record1.relationship('zone', ResourceIdentifier('dns_zones', zone_result.id()))
 record_result_1 = record1.store()
 
 record2 = Resource('dns_records')
@@ -36,7 +35,7 @@ record2.attribute('name', 'test')
 record2.attribute('type', 'A')
 record2.attribute('content', '192.168.1.200')
 record2.attribute('ttl', 3600)
-record2.relationship('zone', Resource('dns_zones', zone_result.id()))
+record2.relationship('zone', ResourceIdentifier('dns_zones', zone_result.id()))
 record_result_2 = record2.store()
 
 # Change the the 'www' record to an AAAA record.

--- a/examples/new_dns_zones.py
+++ b/examples/new_dns_zones.py
@@ -19,7 +19,7 @@ zone.attribute('dnssec', True)
 # Replace the customer ID with your own customer ID.
 zone.relationship('customer', ResourceIdentifier('customers', 'X09kwRdbbAxN'))
 # Send the new resource to the API.
-zone_result = zone.store()
+zone_result = zone.post()
 
 # Add some records.
 record1 = Resource('dns_records')
@@ -28,7 +28,7 @@ record1.attribute('type', 'A')
 record1.attribute('content', '192.168.1.100')
 record1.attribute('ttl', 3600)
 record1.relationship('zone', ResourceIdentifier('dns_zones', zone_result.id()))
-record_result_1 = record1.store()
+record_result_1 = record1.post()
 
 record2 = Resource('dns_records')
 record2.attribute('name', 'test')
@@ -36,7 +36,7 @@ record2.attribute('type', 'A')
 record2.attribute('content', '192.168.1.200')
 record2.attribute('ttl', 3600)
 record2.relationship('zone', ResourceIdentifier('dns_zones', zone_result.id()))
-record_result_2 = record2.store()
+record_result_2 = record2.post()
 
 # Change the the 'www' record to an AAAA record.
 record_result_1.attribute('type', 'AAAA')

--- a/examples/new_dns_zones.py
+++ b/examples/new_dns_zones.py
@@ -1,0 +1,52 @@
+# Run this script using: python examples/dns_zones.py <YOUR-TOKEN>
+import sys
+from exonetapi import Client
+from dev import DevHelper
+from exonetapi.structures import Resource
+
+# Create a new Client.
+client = Client()
+
+# Authorize with a personal access token.
+# client.authenticator.set_token(sys.argv[1])
+client.authenticator.set_token(DevHelper.token)
+
+print('\nAdd a new DNS zone\n')
+
+# Create a new resource with the desired attributes.
+zone = Resource('dns_zones')
+zone.attribute('name', 'my-new-zone.com')
+zone.attribute('dnssec', True)
+# Replace the customer ID with your own customer ID.
+zone.relationship('customer', Resource('customers', 'X09kwRdbbAxN'))
+# Send the new resource to the API.
+zone_result = zone.store()
+
+# Add some records.
+record1 = Resource('dns_records')
+record1.attribute('name', 'www')
+record1.attribute('type', 'A')
+record1.attribute('content', '192.168.1.100')
+record1.attribute('ttl', 3600)
+record1.relationship('zone', Resource('dns_zones', zone_result.id()))
+record_result_1 = record1.store()
+
+record2 = Resource('dns_records')
+record2.attribute('name', 'test')
+record2.attribute('type', 'A')
+record2.attribute('content', '192.168.1.200')
+record2.attribute('ttl', 3600)
+record2.relationship('zone', Resource('dns_zones', zone_result.id()))
+record_result_2 = record2.store()
+
+# Change the the 'www' record to an AAAA record.
+record_result_1.attribute('type', 'AAAA')
+record_result_1.attribute('content', 'fe80::1ff:fe23:4567:890a')
+record_result_1.patch()
+
+# Delete the test record.
+record_result_2.delete()
+
+print('DNS Zone ID: {}'.format(zone_result.id()))
+print('DNS Record ID: {}'.format(record_result_1.id()))
+print(record_result_1.related('zone').get().attribute('name'))

--- a/examples/new_dns_zones.py
+++ b/examples/new_dns_zones.py
@@ -1,8 +1,8 @@
 # Run this script using: python examples/dns_zones.py <YOUR-TOKEN>
 import sys
 from exonetapi import Client
-from exonetapi.structures import ResourceIdentifier
-from exonetapi.structures import Resource
+from exonetapi.structures import ApiResourceIdentifier
+from exonetapi.structures import ApiResource
 
 # Create a new Client.
 client = Client()
@@ -13,29 +13,29 @@ client.authenticator.set_token(sys.argv[1])
 print('\nAdd a new DNS zone\n')
 
 # Create a new resource with the desired attributes.
-zone = Resource('dns_zones')
+zone = ApiResource('dns_zones')
 zone.attribute('name', 'my-new-zone.com')
 zone.attribute('dnssec', True)
 # Replace the customer ID with your own customer ID.
-zone.relationship('customer', ResourceIdentifier('customers', 'X09kwRdbbAxN'))
+zone.relationship('customer', ApiResourceIdentifier('customers', 'X09kwRdbbAxN'))
 # Send the new resource to the API.
 zone_result = zone.post()
 
 # Add some records.
-record1 = Resource('dns_records')
+record1 = ApiResource('dns_records')
 record1.attribute('name', 'www')
 record1.attribute('type', 'A')
 record1.attribute('content', '192.168.1.100')
 record1.attribute('ttl', 3600)
-record1.relationship('zone', ResourceIdentifier('dns_zones', zone_result.id()))
+record1.relationship('zone', ApiResourceIdentifier('dns_zones', zone_result.id()))
 record_result_1 = record1.post()
 
-record2 = Resource('dns_records')
+record2 = ApiResource('dns_records')
 record2.attribute('name', 'test')
 record2.attribute('type', 'A')
 record2.attribute('content', '192.168.1.200')
 record2.attribute('ttl', 3600)
-record2.relationship('zone', ResourceIdentifier('dns_zones', zone_result.id()))
+record2.relationship('zone', ApiResourceIdentifier('dns_zones', zone_result.id()))
 record_result_2 = record2.post()
 
 # Change the the 'www' record to an AAAA record.

--- a/exonetapi/RequestBuilder.py
+++ b/exonetapi/RequestBuilder.py
@@ -1,6 +1,8 @@
 """
 Build requests to send to the API.
 """
+import warnings
+
 import requests
 
 from .result import Parser
@@ -97,6 +99,10 @@ class RequestBuilder(object):
         return Parser(response.content).parse()
 
     def store(self, resource):
+        warnings.warn("store() is deprecated; use post().", DeprecationWarning)
+        self.post(resource)
+
+    def post(self, resource):
         """Make a POST request to the API with the provided resource as data.
 
         :param resource: The resource to use as POST data.

--- a/exonetapi/RequestBuilder.py
+++ b/exonetapi/RequestBuilder.py
@@ -88,14 +88,11 @@ class RequestBuilder(object):
         :return: A Resource or a Collection of Resources.
         """
 
-        response = requests.get(
+        response = self.__make_call(
+            'GET',
             self.__build_url(identifier),
-            headers=self.__get_headers(),
             params=self.__query_params if not identifier else None
         )
-
-        # Raise exception on failed request.
-        response.raise_for_status()
 
         return Parser(response.content).parse()
 
@@ -105,20 +102,68 @@ class RequestBuilder(object):
         :param resource: The resource to use as POST data.
         :return: A resource or a collection of resources.
         """
-        response = requests.post(
-            self.__build_url(),
-            headers=self.__get_headers(),
-            json={'data': resource.to_json()}
-        )
+        changed_attributes = resource.to_json_changed_attributes()
+        changed_relations = resource.get_json_changed_relationships()
 
-        # Handle validation errors.
-        if response.status_code == 422:
-            raise ValidationException(response)
+        # If there are changed attributes, assume it s a new resource.
+        if len(changed_attributes) > 0:
+            response = self.__make_call('POST', self.__build_url(), {'data': resource.to_json()})
 
-        # Raise exception on failed request.
-        response.raise_for_status()
+            return Parser(response.content).parse()
 
-        return Parser(response.content).parse()
+        # If there are changed relations and no changed attributes, assume a POST to the relation.
+        if len(changed_relations) > 0:
+            responses = []
+            for relation_name in changed_relations:
+                response = self.__make_call(
+                    'POST',
+                    '{}/relationships/{}'.format(self.__build_url(resource.id()), relation_name),
+                    changed_relations[relation_name]
+                )
+                responses.append(Parser(response.content).parse())
+
+            return responses
+
+    def patch(self, resource):
+        changed_attributes = resource.to_json_changed_attributes()
+        changed_relations = resource.get_json_changed_relationships()
+
+        # Patch changed attributes.
+        if len(changed_attributes) > 0:
+            self.__make_call(
+                'PATCH',
+                self.__build_url(resource.id()),
+                {'data': changed_attributes}
+            )
+
+        # Patch changed relations.
+        if len(changed_relations) > 0:
+            for relation_name in changed_relations:
+                self.__make_call(
+                    'PATCH',
+                    '{}/relationships/{}'.format(self.__build_url(resource.id()), relation_name),
+                    changed_relations[relation_name]
+                )
+
+        return True
+
+    def delete(self, resource):
+        changed_relations = resource.get_json_changed_relationships()
+
+        # If no relations are changed, DELETE the whole resource.
+        if len(changed_relations) == 0:
+            self.__make_call('DELETE', self.__build_url(resource.id()))
+
+            return True
+
+        for relation_name in changed_relations:
+            self.__make_call(
+                'DELETE',
+                '{}/relationships/{}'.format(self.__build_url(resource.id()), relation_name),
+                changed_relations[relation_name]
+            )
+
+        return True
 
     def __build_url(self, identifier=None):
         """Get the URL to call, based on all previously called setter methods.
@@ -142,3 +187,21 @@ class RequestBuilder(object):
             'Content-Type': 'application/json',
             'Authorization': 'Bearer %s' % (self.__client.authenticator.get_token())
         }
+
+    def __make_call(self, method, url, json_data=None, params=None):
+        response = requests.request(
+            method,
+            url,
+            headers=self.__get_headers(),
+            json=json_data,
+            params=params
+        )
+
+        # Handle validation errors.
+        if response.status_code == 422:
+            raise ValidationException(response)
+
+        # Raise exception on failed request.
+        response.raise_for_status()
+
+        return response

--- a/exonetapi/create_resource.py
+++ b/exonetapi/create_resource.py
@@ -1,5 +1,5 @@
 from inflection import camelize
-from .structures.Resource import Resource
+from .structures.ApiResource import ApiResource
 
 
 def create_resource(resource):
@@ -10,4 +10,4 @@ def create_resource(resource):
     """
     resource_type = resource['type']
 
-    return type(camelize(resource_type), (Resource,), {})(resource)
+    return type(camelize(resource_type), (ApiResource,), {})(resource)

--- a/exonetapi/result/Parser.py
+++ b/exonetapi/result/Parser.py
@@ -41,6 +41,8 @@ class Parser:
             for attribute_name, attribute_value in resource_data['attributes'].items():
                 resource.attribute(attribute_name, attribute_value)
 
+        resource.reset_changed_attributes()
+
         # Extract and parse all included relations.
         if 'relationships' in resource_data.keys():
             parsed_relations = self.parse_relations(
@@ -52,10 +54,12 @@ class Parser:
             for k, r in parsed_relations.items():
                 resource.set_relationship(k, r)
 
+        resource.reset_changed_relations()
+
         return resource
 
     def parse_relations(self, relationships, origin_type, origin_id):
-        parsedRelations = {}
+        parsed_relations = {}
 
         if relationships:
             for relationName, relation in relationships.items():
@@ -80,6 +84,6 @@ class Parser:
 
                         relationship.set_resource_identifiers(relationships)
 
-                    parsedRelations[relationName] = relationship
+                    parsed_relations[relationName] = relationship
 
-        return parsedRelations
+        return parsed_relations

--- a/exonetapi/result/Parser.py
+++ b/exonetapi/result/Parser.py
@@ -3,7 +3,7 @@ Create object from json resource.
 """
 import json
 from exonetapi.create_resource import create_resource
-from exonetapi.structures import ResourceIdentifier
+from exonetapi.structures import ApiResourceIdentifier
 from exonetapi.structures.Relationship import Relationship
 
 
@@ -17,9 +17,9 @@ class Parser:
         self.__json_data = json.loads(self.__data).get('data')
 
     def parse(self):
-        """Parse JSON string into a Resource or a list of Resources.
+        """Parse JSON string into a ApiResource or a list of Resources.
 
-        :return list|Resource: List with Resources or a single Resource.
+        :return list|ApiResource: List with ApiResources or a single ApiResource.
         """
         if type(self.__json_data) is list:
             resources = []
@@ -70,14 +70,14 @@ class Parser:
                     # Set a single relationship.
                     if 'type' in relation['data']:
                         relationship.set_resource_identifiers(
-                            ResourceIdentifier(relation['data']['type'], relation['data']['id'])
+                            ApiResourceIdentifier(relation['data']['type'], relation['data']['id'])
                         )
 
                     # Set a multi relationship.
                     elif isinstance(relation['data'], list):
                         relationships = []
                         for relationItem in relation['data']:
-                            relationships.append(ResourceIdentifier(
+                            relationships.append(ApiResourceIdentifier(
                                 relationItem['type'],
                                 relationItem['id'])
                             )

--- a/exonetapi/structures/ApiResource.py
+++ b/exonetapi/structures/ApiResource.py
@@ -4,10 +4,10 @@ Work with API resources.
 import warnings
 
 import exonetapi.RequestBuilder
-from exonetapi.structures.ResourceIdentifier import ResourceIdentifier
+from exonetapi.structures.ApiResourceIdentifier import ApiResourceIdentifier
 
 
-class Resource(ResourceIdentifier):
+class ApiResource(ApiResourceIdentifier):
     """Basic Resource with attributes.
     """
     def __init__(self, data_or_type, resource_id=None):

--- a/exonetapi/structures/ApiResourceIdentifier.py
+++ b/exonetapi/structures/ApiResourceIdentifier.py
@@ -6,8 +6,8 @@ from exonetapi.structures.Relation import Relation
 from exonetapi.structures.Relationship import Relationship
 
 
-class ResourceIdentifier(object):
-    """Basic Resource identifier.
+class ApiResourceIdentifier(object):
+    """Basic ApiResource identifier.
     """
     def __init__(self, type, id=None):
         """Initialize the resource.
@@ -24,14 +24,14 @@ class ResourceIdentifier(object):
         self.__relationships = {}
 
     def type(self):
-        """Get the resource type of this Resource instance.
+        """Get the resource type of this ApiResource instance.
 
         :return: The resource type.
         """
         return self.__type
 
     def id(self):
-        """Get the resource id of this Resource instance.
+        """Get the resource id of this ApiResource instance.
 
         :return: The resource id.
         """
@@ -57,7 +57,7 @@ class ResourceIdentifier(object):
         is returned.
 
         :param name: The name of the relation to set.
-        :param data: The value of the relation, can be a Resource or a dict of Resources.
+        :param data: The value of the relation, can be a ApiResource or a dict of Resources.
         :return self: when setting a relationship, or the actual relationship when getting it
         """
         if len(data) is 1:
@@ -78,10 +78,10 @@ class ResourceIdentifier(object):
 
     def set_relationship(self, name, data):
         """Define a new relationship for this resource or replace an existing one.
-        Can be a relation to a single Resource or a dict of Resources.
+        Can be a relation to a single ApiResource or a dict of Resources.
 
         :param name: The name of the relation to set.
-        :param data: The value of the relation, can be a Resource or a dict of Resources.
+        :param data: The value of the relation, can be a ApiResource or a dict of Resources.
         :return: self
         """
 
@@ -91,7 +91,7 @@ class ResourceIdentifier(object):
         return self
 
     def to_json(self):
-        """Convert a ResourceIdentifier to JSON.
+        """Convert a ApiResourceIdentifier to JSON.
 
         :return: A dict with the resource type and ID.
         """

--- a/exonetapi/structures/Resource.py
+++ b/exonetapi/structures/Resource.py
@@ -1,6 +1,8 @@
 """
 Work with API resources.
 """
+import warnings
+
 import exonetapi.RequestBuilder
 from exonetapi.structures.ResourceIdentifier import ResourceIdentifier
 
@@ -103,7 +105,11 @@ class Resource(ResourceIdentifier):
         return exonetapi.RequestBuilder(self.type()).patch(self)
 
     def store(self):
-        return exonetapi.RequestBuilder(self.type()).store(self)
+        warnings.warn("store() is deprecated; use post().", DeprecationWarning)
+        return self.post()
+
+    def post(self):
+        return exonetapi.RequestBuilder(self.type()).post(self)
 
     def delete(self):
         return exonetapi.RequestBuilder(self.type()).delete(self)

--- a/exonetapi/structures/Resource.py
+++ b/exonetapi/structures/Resource.py
@@ -1,20 +1,29 @@
 """
 Work with API resources.
 """
-
+import exonetapi.RequestBuilder
 from exonetapi.structures.ResourceIdentifier import ResourceIdentifier
 
 
 class Resource(ResourceIdentifier):
     """Basic Resource with attributes.
     """
-    def __init__(self, data):
-        # Call parent init method.
-        super().__init__(
-            data['type'],
-            data['id'] if 'id' in data else None
-        )
+    def __init__(self, data_or_type, resource_id=None):
+        data = dict()
 
+        if type(data_or_type) is str:
+            data['type'] = data_or_type
+            data['id'] = resource_id
+        elif type(data_or_type) is dict:
+            data['type'] = data_or_type['type']
+            data['id'] = data_or_type['id'] if 'id' in data_or_type else None
+        else:
+            raise ValueError("First argument must be a string or dict.")
+
+        # Call parent init method.
+        super().__init__(data['type'], data['id'])
+
+        self.__changed_attributes = []
         self.__attributes = {}
 
     def attribute(self, item, value=None):
@@ -24,13 +33,16 @@ class Resource(ResourceIdentifier):
         :param value: The new value of the attribute.
         :return: The attribute or None when attribute does not exist.
         """
-        if value:
+        if value is not None:
             self.__attributes[item] = value
+            self.__changed_attributes.append(item)
+            return self
 
         return self.__attributes.get(item)
 
     def attributes(self):
         """Get all resource attributes.
+
         :return: All defined attributes in a dict.
         """
         return self.__attributes
@@ -55,6 +67,30 @@ class Resource(ResourceIdentifier):
 
         return json
 
+    def to_json_changed_attributes(self):
+        """Convert the changed attributes of the resource to a dict according to
+        the JSON-API format.
+
+        :return: The dict with changed attributes according to JSON-API spec.
+        """
+        attributes = {}
+
+        if len(self.__changed_attributes) == 0:
+            return attributes
+
+        for changed_attribute in self.__changed_attributes:
+            attributes[changed_attribute] = self.attributes().get(changed_attribute)
+
+        json = {
+            'type': self.type(),
+            'attributes': attributes,
+        }
+
+        if self.id():
+            json['id'] = self.id()
+
+        return json
+
     def to_json_resource_identifier(self):
         """Convert a Resource to JSON, including only the type and ID.
 
@@ -63,3 +99,15 @@ class Resource(ResourceIdentifier):
 
         return super().to_json()
 
+    def patch(self):
+        return exonetapi.RequestBuilder(self.type()).patch(self)
+
+    def store(self):
+        return exonetapi.RequestBuilder(self.type()).store(self)
+
+    def delete(self):
+        return exonetapi.RequestBuilder(self.type()).delete(self)
+
+    def reset_changed_attributes(self):
+        self.__changed_attributes = []
+        return self

--- a/exonetapi/structures/ResourceIdentifier.py
+++ b/exonetapi/structures/ResourceIdentifier.py
@@ -115,12 +115,19 @@ class ResourceIdentifier(object):
             if type(relation) is list:
                 relation_list = []
                 for relation_resource in relation:
-                    relation_list.append(relation_resource.to_json_resource_identifier())
+                    try:
+                        identifier = relation_resource.to_json_resource_identifier()
+                    except AttributeError:
+                        identifier = relation_resource.to_json()
+                    relation_list.append(identifier)
                 relationships[relation_name]['data'] = relation_list
             elif type(relation) is dict:
                 relationships[relation_name]['data'] = relation['data']
             else:
-                relationships[relation_name]['data'] = relation.to_json_resource_identifier()
+                try:
+                    relationships[relation_name]['data'] = relation.to_json_resource_identifier()
+                except AttributeError:
+                    relationships[relation_name]['data'] = relation.to_json()
 
         return relationships
 

--- a/exonetapi/structures/__init__.py
+++ b/exonetapi/structures/__init__.py
@@ -1,2 +1,2 @@
-from .Resource import Resource
-from .ResourceIdentifier import ResourceIdentifier
+from .ApiResource import ApiResource
+from .ApiResourceIdentifier import ApiResourceIdentifier

--- a/tests/structures/testResource.py
+++ b/tests/structures/testResource.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from tests.testCase import testCase
 
-from exonetapi.structures.Resource import Resource
+from exonetapi.structures.ApiResource import ApiResource
 from exonetapi import create_resource
 
 import json
@@ -25,7 +25,7 @@ class testResource(testCase):
         self.assertEqual(resource.attributes(), {'first_name': 'John', 'last_name': 'Doe', })
 
     def test_init_string(self):
-        resource = Resource('fake', 'abc')
+        resource = ApiResource('fake', 'abc')
         resource.attribute('first_name', 'John')
         resource.attribute('last_name', 'Doe')
 
@@ -36,7 +36,7 @@ class testResource(testCase):
 
     def test_init_invalid(self):
         with self.assertRaises(ValueError):
-            Resource(1234)
+            ApiResource(1234)
 
     def test_init_relationship(self):
         resource = create_resource({
@@ -79,7 +79,7 @@ class testResource(testCase):
         })
 
     def test_to_json(self):
-        resource = Resource({
+        resource = ApiResource({
             'type': 'fake',
             'id': 'FakeID',
         })
@@ -109,7 +109,7 @@ class testResource(testCase):
         )
 
     def test_to_json_changed_attributes(self):
-        resource = Resource({
+        resource = ApiResource({
             'type': 'fake',
             'id': 'FakeID',
         })
@@ -133,26 +133,26 @@ class testResource(testCase):
     @mock.patch('exonetapi.RequestBuilder.patch')
     def test_patch(self, mock_requestbuilder_patch, mock_requestbuilder_init):
         mock_requestbuilder_patch.patch = MagicMock(return_value=None)
-        Resource({'type': 'fake', 'id': 'FakeID'}).patch()
+        ApiResource({'type': 'fake', 'id': 'FakeID'}).patch()
         mock_requestbuilder_init.assert_called_with('fake')
 
     @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
     @mock.patch('exonetapi.RequestBuilder.delete')
     def test_delete(self, mock_requestbuilder_delete, mock_requestbuilder_init):
         mock_requestbuilder_delete.delete = MagicMock(return_value=None)
-        Resource({'type': 'fake', 'id': 'FakeID'}).delete()
+        ApiResource({'type': 'fake', 'id': 'FakeID'}).delete()
         mock_requestbuilder_init.assert_called_with('fake')
 
     @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
     @mock.patch('exonetapi.RequestBuilder.post')
     def test_post(self, mock_requestbuilder_post, mock_requestbuilder_init):
         mock_requestbuilder_post.post = MagicMock(return_value=None)
-        Resource({'type': 'fake', 'id': 'FakeID'}).post()
+        ApiResource({'type': 'fake', 'id': 'FakeID'}).post()
         mock_requestbuilder_init.assert_called_with('fake')
 
 
     def test_reset_changed_attributes(self):
-        resource = Resource({
+        resource = ApiResource({
             'type': 'fake',
             'id': 'FakeID',
         })

--- a/tests/structures/testResource.py
+++ b/tests/structures/testResource.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import MagicMock
+from unittest import mock
 
 from tests.testCase import testCase
 
@@ -21,6 +23,20 @@ class testResource(testCase):
         self.assertEqual(resource.type(), 'fake')
         self.assertIsNone(resource.id())
         self.assertEqual(resource.attributes(), {'first_name': 'John', 'last_name': 'Doe', })
+
+    def test_init_string(self):
+        resource = Resource('fake', 'abc')
+        resource.attribute('first_name', 'John')
+        resource.attribute('last_name', 'Doe')
+
+        self.assertEqual(resource.attribute('first_name'), 'John')
+        self.assertEqual(resource.type(), 'fake')
+        self.assertEqual(resource.id(), 'abc')
+        self.assertEqual(resource.attributes(), {'first_name': 'John', 'last_name': 'Doe', })
+
+    def test_init_invalid(self):
+        with self.assertRaises(ValueError):
+            Resource(1234)
 
     def test_init_relationship(self):
         resource = create_resource({
@@ -91,6 +107,65 @@ class testResource(testCase):
                 }
             })
         )
+
+    def test_to_json_changed_attributes(self):
+        resource = Resource({
+            'type': 'fake',
+            'id': 'FakeID',
+        })
+        self.assertEqual({}, resource.to_json_changed_attributes())
+
+        resource.attribute('test', 'Hello World')
+        resource.set_relationship(
+            'thing',
+            create_resource({
+                'type': 'things',
+                'id': 'thingID',
+            })
+        )
+
+        self.assertEqual(
+            json.dumps({"type": "fake", "attributes": {"test": "Hello World"}, "id": "FakeID"}),
+            json.dumps(resource.to_json_changed_attributes())
+        )
+
+    @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
+    @mock.patch('exonetapi.RequestBuilder.patch')
+    def test_patch(self, mock_requestbuilder_patch, mock_requestbuilder_init):
+        mock_requestbuilder_patch.patch = MagicMock(return_value=None)
+        Resource({'type': 'fake', 'id': 'FakeID'}).patch()
+        mock_requestbuilder_init.assert_called_with('fake')
+
+    @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
+    @mock.patch('exonetapi.RequestBuilder.delete')
+    def test_delete(self, mock_requestbuilder_delete, mock_requestbuilder_init):
+        mock_requestbuilder_delete.delete = MagicMock(return_value=None)
+        Resource({'type': 'fake', 'id': 'FakeID'}).delete()
+        mock_requestbuilder_init.assert_called_with('fake')
+
+    @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
+    @mock.patch('exonetapi.RequestBuilder.store')
+    def test_store(self, mock_requestbuilder_store, mock_requestbuilder_init):
+        mock_requestbuilder_store.store = MagicMock(return_value=None)
+        Resource({'type': 'fake', 'id': 'FakeID'}).store()
+        mock_requestbuilder_init.assert_called_with('fake')
+
+
+    def test_reset_changed_attributes(self):
+        resource = Resource({
+            'type': 'fake',
+            'id': 'FakeID',
+        })
+        resource.attribute('test', 'Hello World')
+
+        self.assertEqual(
+            {'attributes': {'test': 'Hello World'}, 'id': 'FakeID', 'type': 'fake'},
+            resource.to_json_changed_attributes()
+        )
+
+        resource.reset_changed_attributes()
+        self.assertEqual({}, resource.to_json_changed_attributes())
+
 
 
 if __name__ == '__main__':

--- a/tests/structures/testResource.py
+++ b/tests/structures/testResource.py
@@ -144,10 +144,10 @@ class testResource(testCase):
         mock_requestbuilder_init.assert_called_with('fake')
 
     @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
-    @mock.patch('exonetapi.RequestBuilder.store')
-    def test_store(self, mock_requestbuilder_store, mock_requestbuilder_init):
-        mock_requestbuilder_store.store = MagicMock(return_value=None)
-        Resource({'type': 'fake', 'id': 'FakeID'}).store()
+    @mock.patch('exonetapi.RequestBuilder.post')
+    def test_post(self, mock_requestbuilder_post, mock_requestbuilder_init):
+        mock_requestbuilder_post.post = MagicMock(return_value=None)
+        Resource({'type': 'fake', 'id': 'FakeID'}).post()
         mock_requestbuilder_init.assert_called_with('fake')
 
 

--- a/tests/structures/testResourceIdentifier.py
+++ b/tests/structures/testResourceIdentifier.py
@@ -149,7 +149,7 @@ class testResourceIdentifier(testCase):
 
     @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
     @mock.patch('exonetapi.RequestBuilder.get')
-    def test_store(self, mock_requestbuilder_get, mock_requestbuilder_init):
+    def test_post(self, mock_requestbuilder_get, mock_requestbuilder_init):
         mock_requestbuilder_get.get = MagicMock(return_value=None)
         Resource({'type': 'fake', 'id': 'FakeID'}).get()
         mock_requestbuilder_get.assert_called_with('FakeID')

--- a/tests/structures/testResourceIdentifier.py
+++ b/tests/structures/testResourceIdentifier.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest import mock
+from unittest.mock import MagicMock
 
 from tests.testCase import testCase
 
@@ -59,6 +61,13 @@ class testResourceIdentifier(testCase):
         resource = create_resource({
             'type': 'fake'
         })
+        resource.relationship('ignored', {
+            'data' : {
+                'type': 'this',
+                'id': 'that',
+            }
+        })
+        resource.reset_changed_relations()
 
         resource.relationship('messages', {
             'data' : {
@@ -68,7 +77,31 @@ class testResourceIdentifier(testCase):
         })
 
         self.assertEqual(
-            resource.get_json_relationships(),
+            resource.get_json_changed_relationships(),
+            {
+                'messages': {
+                    'data': {
+                        'id': 'that',
+                        'type': 'this'
+                    }
+                }
+            }
+        )
+
+    def test_get_json_changed_relationships(self):
+        resource = create_resource({
+            'type': 'fake'
+        })
+
+        resource.relationship('messages', {
+            'data' : {
+                'type': 'this',
+                'id': 'that',
+            }
+        })
+
+        self.assertEqual(
+            resource.get_json_changed_relationships(),
             {
                 'messages': {
                     'data': {
@@ -117,6 +150,13 @@ class testResourceIdentifier(testCase):
         relation = resource.related('something')
         self.assertIsInstance(relation, Relation)
 
+    @mock.patch('exonetapi.RequestBuilder.__init__', return_value=None)
+    @mock.patch('exonetapi.RequestBuilder.get')
+    def test_store(self, mock_requestbuilder_get, mock_requestbuilder_init):
+        mock_requestbuilder_get.get = MagicMock(return_value=None)
+        Resource({'type': 'fake', 'id': 'FakeID'}).get()
+        mock_requestbuilder_get.assert_called_with('FakeID')
+        mock_requestbuilder_init.assert_called_with('fake')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/structures/testResourceIdentifier.py
+++ b/tests/structures/testResourceIdentifier.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from tests.testCase import testCase
 
+from exonetapi.structures import ResourceIdentifier
 from exonetapi.structures.Resource import Resource
 from exonetapi.structures.Relationship import Relationship
 from exonetapi.structures.Relation import Relation
@@ -62,29 +63,25 @@ class testResourceIdentifier(testCase):
             'type': 'fake'
         })
         resource.relationship('ignored', {
-            'data' : {
+            'data': {
                 'type': 'this',
                 'id': 'that',
             }
         })
         resource.reset_changed_relations()
 
-        resource.relationship('messages', {
-            'data' : {
-                'type': 'this',
-                'id': 'that',
-            }
-        })
+        resource.relationship('object', {'data': {'type': 'this', 'id': 'that'}})
+        resource.relationship('resource', Resource('this', 'that'))
+        resource.relationship('resource_identifier', ResourceIdentifier('this', 'that'))
+        resource.relationship('list', [ResourceIdentifier('this', 'that')])
 
         self.assertEqual(
             resource.get_json_changed_relationships(),
             {
-                'messages': {
-                    'data': {
-                        'id': 'that',
-                        'type': 'this'
-                    }
-                }
+                'object': {'data': {'id': 'that', 'type': 'this'}},
+                'resource': {'data': {'id': 'that', 'type': 'this'}},
+                'resource_identifier': {'data': {'id': 'that', 'type': 'this'}},
+                'list': {'data': [{'id': 'that', 'type': 'this'}]},
             }
         )
 

--- a/tests/structures/testResourceIdentifier.py
+++ b/tests/structures/testResourceIdentifier.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock
 
 from tests.testCase import testCase
 
-from exonetapi.structures import ResourceIdentifier
-from exonetapi.structures.Resource import Resource
+from exonetapi.structures import ApiResourceIdentifier
+from exonetapi.structures.ApiResource import ApiResource
 from exonetapi.structures.Relationship import Relationship
 from exonetapi.structures.Relation import Relation
 from exonetapi import create_resource
@@ -71,9 +71,9 @@ class testResourceIdentifier(testCase):
         resource.reset_changed_relations()
 
         resource.relationship('object', {'data': {'type': 'this', 'id': 'that'}})
-        resource.relationship('resource', Resource('this', 'that'))
-        resource.relationship('resource_identifier', ResourceIdentifier('this', 'that'))
-        resource.relationship('list', [ResourceIdentifier('this', 'that')])
+        resource.relationship('resource', ApiResource('this', 'that'))
+        resource.relationship('resource_identifier', ApiResourceIdentifier('this', 'that'))
+        resource.relationship('list', [ApiResourceIdentifier('this', 'that')])
 
         self.assertEqual(
             resource.get_json_changed_relationships(),
@@ -110,7 +110,7 @@ class testResourceIdentifier(testCase):
         )
 
     def test_to_json(self):
-        resource = Resource({
+        resource = ApiResource({
             'type': 'fake',
             'id': 'FakeID',
         })
@@ -151,7 +151,7 @@ class testResourceIdentifier(testCase):
     @mock.patch('exonetapi.RequestBuilder.get')
     def test_post(self, mock_requestbuilder_get, mock_requestbuilder_init):
         mock_requestbuilder_get.get = MagicMock(return_value=None)
-        Resource({'type': 'fake', 'id': 'FakeID'}).get()
+        ApiResource({'type': 'fake', 'id': 'FakeID'}).get()
         mock_requestbuilder_get.assert_called_with('FakeID')
         mock_requestbuilder_init.assert_called_with('fake')
 

--- a/tests/testRequestBuilder.py
+++ b/tests/testRequestBuilder.py
@@ -5,7 +5,7 @@ from unittest import mock
 from tests.testCase import testCase
 from exonetapi import Client
 from exonetapi.RequestBuilder import RequestBuilder
-from exonetapi.structures.Resource import Resource
+from exonetapi.structures.ApiResource import ApiResource
 from exonetapi.exceptions.ValidationException import ValidationException
 
 
@@ -102,7 +102,7 @@ class testRequestBuilder(testCase):
     @mock.patch('exonetapi.result.Parser.__init__')
     @mock.patch('requests.request')
     def test_post(self, mock_requests_request, mock_parser_init, mock_parser_parse):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.to_json = MagicMock(return_value={'name': 'my_name'})
         resource.to_json_changed_attributes = MagicMock(return_value={'name': 'my_name'})
 
@@ -132,7 +132,7 @@ class testRequestBuilder(testCase):
     @mock.patch('exonetapi.result.Parser.__init__')
     @mock.patch('requests.request')
     def test_post_relation(self, mock_requests_request, mock_parser_init, mock_parser_parse):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.get_json_changed_relationships = MagicMock(return_value={'name': {'data': {'type': 'test', 'id': 1}}})
 
         mock_parser_parse.return_value = 'parsedReturnValue'
@@ -159,7 +159,7 @@ class testRequestBuilder(testCase):
 
     @mock.patch('requests.request')
     def test_patch(self, mock_requests_request):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.to_json = MagicMock(return_value={'name': 'my_name'})
         resource.to_json_changed_attributes = MagicMock(return_value={'name': 'my_name'})
 
@@ -182,7 +182,7 @@ class testRequestBuilder(testCase):
 
     @mock.patch('requests.request')
     def test_patch_relation(self, mock_requests_request):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.get_json_changed_relationships = MagicMock(return_value={'name': {'data': {'type': 'test', 'id': 1}}})
 
         mock_requests_request.return_value = self.MockResponse('{"data": "getReturnData"}')
@@ -204,7 +204,7 @@ class testRequestBuilder(testCase):
 
     @mock.patch('requests.request')
     def test_delete(self, mock_requests_request):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.to_json = MagicMock(return_value={'name': 'my_name'})
         resource.to_json_changed_attributes = MagicMock(return_value={'name': 'my_name'})
 
@@ -227,7 +227,7 @@ class testRequestBuilder(testCase):
 
     @mock.patch('requests.request')
     def test_delete_relation(self, mock_requests_request):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.get_json_changed_relationships = MagicMock(
             return_value={'name': {'data': {'type': 'test', 'id': 1}}})
 
@@ -251,7 +251,7 @@ class testRequestBuilder(testCase):
     @mock.patch('requests.request')
     @mock.patch('exonetapi.exceptions.ValidationException.__init__', return_value=None)
     def test_post_validation_error(self, mock_validation_exception, mock_requests_request):
-        resource = Resource({'type': 'things', 'id': 'someId'})
+        resource = ApiResource({'type': 'things', 'id': 'someId'})
         resource.to_json = MagicMock(return_value={'name': 'my_name'})
         resource.to_json_changed_attributes = MagicMock(return_value={'name': 'my_name'})
 

--- a/tests/testRequestBuilder.py
+++ b/tests/testRequestBuilder.py
@@ -101,7 +101,7 @@ class testRequestBuilder(testCase):
     @mock.patch('exonetapi.result.Parser.parse')
     @mock.patch('exonetapi.result.Parser.__init__')
     @mock.patch('requests.request')
-    def test_store(self, mock_requests_request, mock_parser_init, mock_parser_parse):
+    def test_post(self, mock_requests_request, mock_parser_init, mock_parser_parse):
         resource = Resource({'type': 'things', 'id': 'someId'})
         resource.to_json = MagicMock(return_value={'name': 'my_name'})
         resource.to_json_changed_attributes = MagicMock(return_value={'name': 'my_name'})
@@ -110,7 +110,7 @@ class testRequestBuilder(testCase):
         mock_parser_init.return_value = None
         mock_requests_request.return_value = self.MockResponse('{"data": "getReturnData"}')
 
-        result = self.request_builder.store(resource)
+        result = self.request_builder.post(resource)
 
         mock_requests_request.assert_called_with(
             'POST',
@@ -131,7 +131,7 @@ class testRequestBuilder(testCase):
     @mock.patch('exonetapi.result.Parser.parse')
     @mock.patch('exonetapi.result.Parser.__init__')
     @mock.patch('requests.request')
-    def test_store_relation(self, mock_requests_request, mock_parser_init, mock_parser_parse):
+    def test_post_relation(self, mock_requests_request, mock_parser_init, mock_parser_parse):
         resource = Resource({'type': 'things', 'id': 'someId'})
         resource.get_json_changed_relationships = MagicMock(return_value={'name': {'data': {'type': 'test', 'id': 1}}})
 
@@ -139,7 +139,7 @@ class testRequestBuilder(testCase):
         mock_parser_init.return_value = None
         mock_requests_request.return_value = self.MockResponse('{"data": "getReturnData"}')
 
-        result = self.request_builder.store(resource)
+        result = self.request_builder.post(resource)
 
         mock_requests_request.assert_called_with(
             'POST',
@@ -250,14 +250,14 @@ class testRequestBuilder(testCase):
 
     @mock.patch('requests.request')
     @mock.patch('exonetapi.exceptions.ValidationException.__init__', return_value=None)
-    def test_store_validation_error(self, mock_validation_exception, mock_requests_request):
+    def test_post_validation_error(self, mock_validation_exception, mock_requests_request):
         resource = Resource({'type': 'things', 'id': 'someId'})
         resource.to_json = MagicMock(return_value={'name': 'my_name'})
         resource.to_json_changed_attributes = MagicMock(return_value={'name': 'my_name'})
 
         mock_requests_request.return_value = self.MockResponse('{"data": "getReturnData"}', 422)
 
-        self.assertRaises(ValidationException, self.request_builder.store, resource)
+        self.assertRaises(ValidationException, self.request_builder.post, resource)
 
         mock_requests_request.assert_called_with(
             'POST',


### PR DESCRIPTION
In this PR support is added for PATCH and DELETE requests. Also, the `store` method is deprecated in favour of `post`.

See the [example](https://github.com/exonet/exonet-api-python/blob/tsi-EXO-3833/examples/new_dns_zones.py) on how to use and test.