### PR TITLE
Pagination and recursive calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 .coverage.*
 .pytest_cache/*
 /htmlcov/
+/dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to `exonet-api-python` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased]
-[Compare 2.0.0 - Unreleased](https://github.com/exonet/exonet-api-python/compare/2.0.0...master)
+[Compare 3.0.0 - Unreleased](https://github.com/exonet/exonet-api-python/compare/3.0.0...master)
+
+## [3.0.0](https://github.com/exonet/exonet-api-python/releases/tag/3.0.0) - 2020-09-11
+[Compare 2.1.0 - 3.0.0](https://github.com/exonet/exonet-api-python/compare/2.1.0...3.0.0)
 ### Breaking
 - When multiple resources are returned from the API, an instance of `ApiResourceSet` is returned instead of a list. This class is traversable so unless the code does specific `list` things or type checks, no changes are necessary.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 [Compare 2.0.0 - Unreleased](https://github.com/exonet/exonet-api-python/compare/2.0.0...master)
+### Breaking
+- When multiple resources are returned from the API, an instance of `ApiResourceSet` is returned instead of a list. This class is traversable so unless the code does specific `list` things or type checks, no changes are necessary.
+
+### Added
+- Add the `total()` method to resource sets to get the total number of resources (and not only the number of resources in the current resource set).
+- Add `next_page`, `previous_page`, `first_page` and `last_page` methods to the `ApiResourceSet` for easy loading of paginated resource sets.
+- Add a `get_recursive` method to the `RequestBuilder` to get the resource set including recursively the resource sets from the following pages.
+
+### Removed
+- The `store` method for creating `POST` requests. (Deprecated since 2.0.0)
 
 ## [2.1.0](https://github.com/exonet/exonet-api-python/releases/tag/2.1.0) - 2019-11-19
 [Compare 2.0.0 - 2.1.0](https://github.com/exonet/exonet-api-python/compare/2.0.0...2.1.0)

--- a/docs/calls.md
+++ b/docs/calls.md
@@ -27,6 +27,19 @@ After setting the options you can call the `get()` method to retrieve the resour
 certificates = certificates_request.get()
 ```
 
+It is also possible to get all resource sets recursively. The package will check the URL defined in `links.next` and as
+long as the value is not `null` it will make an additional request and merge the results:
+
+```python
+certificates = certificates_request.get_recursive()
+```
+
+Please note that the `get_recursive` method respects pagination and filters. So the following example will get all
+non-expired certificates, starting from page two in batches of ten:
+```python
+certificates = certificates_request.filter('expired', False).page(2).size.get_recursive()
+```
+
 ## Getting a single resource by ID
 If you want to get a specific resource by its ID, you can pass it as an argument to the `get` method:
 ```python

--- a/docs/responses.md
+++ b/docs/responses.md
@@ -1,6 +1,37 @@
 # Working with API Responses
 There are two types of API responses upon a successful request. If a single resource is requested then a [`ApiResource`](resources.md) instance is
-returned, if multiple resources are requested then an `list` of `ApiResource`'s is returned.
+returned, if multiple resources are requested then an `ApiResourceSet` is returned.
+
+## The `ApiResourceSet` class
+When the API returns multiple resources, for example when getting an overview page, an instance of the `ApiResourceSet` class
+is returned. The instance of this class contains the requested resources. Traverse each individual resource by using a
+`for`-loop on the instance:
+```python
+certificates = client.resource('certificates').get()
+for certificate in certificates:
+    # Each item is an instance of an ApiResource.
+    print(certificate.id())
+```
+
+The get the number of items in a resource set, you can use one of the following methods:
+```php
+len(certificates); // Returns the number of resources in the current resource set.
+certificates.total() // Returns the total number of resources in the resource set, ignoring pagination.
+```
+
+If `len != total` you can get the next/previous/first/last page by calling one of the pagination methods:
+```python
+# Get the next resource set:
+certificates.next_page()
+# Get the previous resource set:
+certificates.previous_page()
+# Get the first resource set:
+certificates.first_page()
+# Get the last resource set:
+certificates.last_page()
+```
+
+Each of this methods will return `None` if not available.
 
 ## The [`ApiResource`](resources.md) class
 Each resource returned by the API is transformed to an [`ApiResource`](resources.md) instance. This makes it possible to have easy access
@@ -19,24 +50,6 @@ print(
         expire_date=certificate.attribute('expires_at')
     )
 )
-```
-
-## Multiple resources
-When the API returns multiple resources, for example when getting an overview page, a list is returned.
-This list contains the requested resources. Iterate over the list to handle the resources:
-
-```python
-
-# Get all certificates
-certificates = client.resource('certificates').size(10).get()
-
-for certificate in certificates:
-    print(
-        '- {domain} Expires at {expire_date}'.format(
-            domain=certificate.attribute('domain'),
-            expire_date=certificate.attribute('expires_at')
-        )
-    )
 ```
 
 ---

--- a/examples/dns_zone_details.py
+++ b/examples/dns_zone_details.py
@@ -9,9 +9,10 @@ client = Client()
 client.authenticator.set_token(sys.argv[1])
 
 '''
-Get a single dns_zone resource. Because depending on who is authorized, the dns_zone IDs change, all dns_zones are
-retrieved with a limit of 1. From this result, the first DNS zone is used. In a real world scenario you would call
-something like `zone = client.resource('dns_zones').get('VX09kwR3KxNo')` to get a single DNS zone by it's ID.
+Get a single dns_zone resource. Because depending on who is authorized, the dns_zone IDs change, all
+dns_zones are retrieved with a limit of 1. From this result, the first DNS zone is used. In a real
+world scenario you would call something like
+`zone = client.resource('dns_zones').get('VX09kwR3KxNo')` to get a single DNS zone by it's ID.
 '''
 zones = client.resource('dns_zones').size(1).get()
 

--- a/examples/ticket_details.py
+++ b/examples/ticket_details.py
@@ -9,9 +9,10 @@ client = Client()
 client.authenticator.set_token(sys.argv[1])
 
 '''
-Get a single ticket resource. Because depending on who is authorized, the ticket IDs change, all tickets are
-retrieved with a limit of 1. From this result, the first ticket is used. In a real world scenario you would call
-something like `ticket = client.resource('tickets').get('VX09kwR3KxNo')` to get a single ticket by it's ID.
+Get a single ticket resource. Because depending on who is authorized, the ticket IDs change, all
+tickets are retrieved with a limit of 1. From this result, the first ticket is used. In a real world
+scenario you would call something like `ticket = client.resource('tickets').get('VX09kwR3KxNo')` to
+get a single ticket by it's ID.
 '''
 tickets = client.resource('tickets').size(1).get()
 

--- a/exonetapi/RequestBuilder.py
+++ b/exonetapi/RequestBuilder.py
@@ -103,10 +103,6 @@ class RequestBuilder(object):
     def get_recursive(self):
         return self.__get_recursive()
 
-    def store(self, resource):
-        warnings.warn("store() is deprecated; use post().", DeprecationWarning)
-        self.post(resource)
-
     def post(self, resource):
         """Make a POST request to the API with the provided resource as data.
 

--- a/exonetapi/RequestBuilder.py
+++ b/exonetapi/RequestBuilder.py
@@ -1,20 +1,22 @@
 """
 Build requests to send to the API.
 """
+import json
 import warnings
 
 import requests
 
-from .result import Parser
+from exonetapi.structures import ApiResourceSet
 from exonetapi.exceptions.ValidationException import ValidationException
+from .result import Parser
 
 
 class RequestBuilder(object):
     """Create and make requests to the API.
     """
 
-    def __init__(self, resource, client=None):
-        if not resource.startswith('/'):
+    def __init__(self, resource=None, client=None):
+        if resource is not None and not resource.startswith('/'):
             resource = '/' + resource
 
         self.__resource = resource
@@ -98,6 +100,9 @@ class RequestBuilder(object):
 
         return Parser(response.content).parse()
 
+    def get_recursive(self):
+        return self.__get_recursive()
+
     def store(self, resource):
         warnings.warn("store() is deprecated; use post().", DeprecationWarning)
         self.post(resource)
@@ -176,7 +181,10 @@ class RequestBuilder(object):
 
         :return: A URL.
         """
-        url = self.__client.get_host() + self.__resource
+        url = self.__client.get_host()
+
+        if self.__resource is not None:
+            url += self.__resource
 
         if identifier:
             url += '/' + identifier
@@ -211,3 +219,32 @@ class RequestBuilder(object):
         response.raise_for_status()
 
         return response
+
+    def __get_recursive(self, data=None, url=None):
+        """
+        Get the URL and call this method recursivly as long as there is an URL in the 'next' field
+        of the 'links' data.
+
+        :param data: The ApiResourceSet to append the resources to.
+        :param url: The URL to call.
+        :return: The ApiResourceSet containing all requested resources.
+        """
+        response = self.__make_call(
+            'GET',
+            url or self.__build_url(),
+            params=self.__query_params if not url else None
+        )
+
+        content = Parser(response.content).parse()
+
+        if data is None:
+            data = ApiResourceSet()
+            data.set_meta(content.meta().copy())
+
+        data.add_resource(content.resources())
+
+        next_link = content.links().get('next')
+        if next_link is not None:
+            return self.__get_recursive(data, next_link)
+
+        return data

--- a/exonetapi/result/Parser.py
+++ b/exonetapi/result/Parser.py
@@ -3,7 +3,7 @@ Create object from json resource.
 """
 import json
 from exonetapi.create_resource import create_resource
-from exonetapi.structures import ApiResourceIdentifier
+from exonetapi.structures import ApiResourceIdentifier, ApiResourceSet
 from exonetapi.structures.Relationship import Relationship
 
 
@@ -14,17 +14,23 @@ class Parser:
 
     def __init__(self, data):
         self.__data = data
-        self.__json_data = json.loads(self.__data).get('data')
+        self.__json = json.loads(self.__data)
+        self.__json_data = self.__json.get('data')
 
     def parse(self):
         """Parse JSON string into a ApiResource or a list of Resources.
 
-        :return list|ApiResource: List with ApiResources or a single ApiResource.
+        :return ApiResourceSet|ApiResource: An ApiResourceSet or a single ApiResource.
         """
         if type(self.__json_data) is list:
-            resources = []
+            resources = ApiResourceSet()
+            resources \
+                .set_meta(self.__json.get('meta')) \
+                .set_links(self.__json.get('links'))
+
             for resource_data in self.__json_data:
-                resources.append(self.make_resource(resource_data))
+                resource = self.make_resource(resource_data)
+                resources.add_resource(resource)
 
             return resources
         else:

--- a/exonetapi/structures/ApiResource.py
+++ b/exonetapi/structures/ApiResource.py
@@ -104,10 +104,6 @@ class ApiResource(ApiResourceIdentifier):
     def patch(self):
         return exonetapi.RequestBuilder(self.type()).patch(self)
 
-    def store(self):
-        warnings.warn("store() is deprecated; use post().", DeprecationWarning)
-        return self.post()
-
     def post(self):
         return exonetapi.RequestBuilder(self.type()).post(self)
 

--- a/exonetapi/structures/ApiResourceIdentifier.py
+++ b/exonetapi/structures/ApiResourceIdentifier.py
@@ -9,6 +9,7 @@ from exonetapi.structures.Relationship import Relationship
 class ApiResourceIdentifier(object):
     """Basic ApiResource identifier.
     """
+
     def __init__(self, type, id=None):
         """Initialize the resource.
         :param type: The type of the resource.
@@ -71,7 +72,7 @@ class ApiResourceIdentifier(object):
         :param name: The name of the relation to get.
         :return: The defined relation or None
         """
-        if not name in self.__relationships.keys():
+        if name not in self.__relationships.keys():
             self.__relationships[name] = Relationship(name, self.type(), self.id())
 
         return self.__relationships[name]

--- a/exonetapi/structures/ApiResourceSet.py
+++ b/exonetapi/structures/ApiResourceSet.py
@@ -1,0 +1,76 @@
+import exonetapi
+
+
+class ApiResourceSet:
+    def __init__(self):
+        self.__resources = []
+        self.__meta = {}
+        self.__links = {}
+        self.__iter_current = 0
+
+    def total(self):
+        return self.__meta.get('resources', {"total": None}).get('total')
+
+    def links(self):
+        return self.__links
+
+    def meta(self):
+        return self.__meta
+
+    def next_page(self):
+        return self.__get_link('next')
+
+    def previous_page(self):
+        return self.__get_link('prev')
+
+    def first_page(self):
+        return self.__get_link('first')
+
+    def last_page(self):
+        return self.__get_link('last')
+
+    def add_resource(self, resource):
+        if isinstance(resource, list):
+            self.__resources.extend(resource)
+        else:
+            self.__resources.append(resource)
+
+    def set_meta(self, meta):
+        self.__meta = meta
+
+        return self
+
+    def set_links(self, links):
+        self.__links = links
+
+        return self
+
+    def resources(self):
+        return self.__resources
+
+    def __get_link(self, link_name):
+        request = exonetapi.RequestBuilder()
+        host = exonetapi.Client().get_host()
+        link_value = self.__links.get(link_name)
+
+        if link_value is not None:
+            return request.get(link_value.replace('{}/'.format(host), ''))
+        else:
+            return None
+
+    def __len__(self):
+        return len(self.__resources)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        current = self.__iter_current
+        self.__iter_current += 1
+
+        if len(self.__resources) > current:
+            return self.__resources[current]
+
+        self.__iter_current = 0
+
+        raise StopIteration

--- a/exonetapi/structures/Relation.py
+++ b/exonetapi/structures/Relation.py
@@ -1,4 +1,3 @@
-
 class Relation(object):
     # string Pattern to create the relation url.
     __urlPattern = '/%s/%s/%s'
@@ -27,7 +26,7 @@ class Relation(object):
 
     def __getattr__(self, name):
         def method():
-            return getattr(self.__request,name)()
+            return getattr(self.__request, name)()
 
         return method
 
@@ -43,7 +42,8 @@ class Relation(object):
         """
         Replace the related resource identifiers with new data.
 
-        :param ApiResourceSet|ApiResourceIdentifier new_relationship: A new resource identifier or a new resource set.
+        :param ApiResourceSet|ApiResourceIdentifier new_relationship: A new resource identifier or a
+        new resource set.
         :return self:
         """
         self.__resourceIdentifiers = new_relationship

--- a/exonetapi/structures/__init__.py
+++ b/exonetapi/structures/__init__.py
@@ -1,2 +1,3 @@
 from .ApiResource import ApiResource
 from .ApiResourceIdentifier import ApiResourceIdentifier
+from .ApiResourceSet import ApiResourceSet

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ idna==2.6
 inflection==0.3.1
 requests==2.20.0
 urllib3==1.24.2
+pycodestyle==2.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pycodestyle]
+max-line-length = 100
+statistics = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [pycodestyle]
 max-line-length = 100
 statistics = True
+exclude=./dev/*

--- a/tests/result/testParser.py
+++ b/tests/result/testParser.py
@@ -51,7 +51,7 @@ class testParser(testCase):
         }
         """
 
-        result = Parser(json_data_list).parse()
+        result = Parser(json_data_list).parse().resources()
 
         self.assertEqual(result[0].id(), 'DV6axK4GwNEb')
         self.assertEqual(result[0].type(), 'comments')

--- a/tests/result/testParser.py
+++ b/tests/result/testParser.py
@@ -6,7 +6,7 @@ from exonetapi.result import Parser
 
 class testParser(testCase):
     def test_parse_list(self):
-        json_data_list = """ 
+        json_data_list = """
         {
           "data": [
             {
@@ -60,7 +60,7 @@ class testParser(testCase):
         self.assertEqual(result[1].type(), 'comments')
 
     def test_parse_single(self):
-        json_data_list = """ 
+        json_data_list = """
         {
           "data":
             {
@@ -91,7 +91,7 @@ class testParser(testCase):
         self.assertEqual(result.type(), 'comments')
 
     def test_parse_single_with_multi_relation(self):
-        json_data_list = """ 
+        json_data_list = """
         {
           "data": {
             "type": "comments",
@@ -113,7 +113,7 @@ class testParser(testCase):
                   {
                     "type": "tags",
                     "id": "XYZ"
-                  }  
+                  }
                 ]
               }
             }
@@ -126,7 +126,7 @@ class testParser(testCase):
         self.assertEqual(len(result), 2)
 
         def test_parse_single_with_multi_relation(self):
-            json_data_list = """ 
+            json_data_list = """
             {
               "data":
                 {

--- a/tests/structures/testApiResource.py
+++ b/tests/structures/testApiResource.py
@@ -10,7 +10,7 @@ from exonetapi import create_resource
 import json
 
 
-class testResource(testCase):
+class testApiResource(testCase):
 
     def test_init(self):
         resource = create_resource({

--- a/tests/structures/testApiResourceIdentifier.py
+++ b/tests/structures/testApiResourceIdentifier.py
@@ -13,7 +13,7 @@ from exonetapi import create_resource
 import json
 
 
-class testResourceIdentifier(testCase):
+class testApiResourceIdentifier(testCase):
 
     def test_init(self):
         resource = create_resource({

--- a/tests/structures/testApiResourceSet.py
+++ b/tests/structures/testApiResourceSet.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest import mock
+
+from exonetapi.structures.ApiResourceSet import ApiResourceSet
+from exonetapi.structures.ApiResource import ApiResource
+from tests.testCase import testCase
+
+
+class testApiResourceSet(testCase):
+
+    def test_total(self):
+        api_resource_set = ApiResourceSet()
+        meta = {'resources': {'total': 1337}}
+        api_resource_set.set_meta(meta)
+
+        self.assertEqual(1337, api_resource_set.total())
+        self.assertEqual(meta, api_resource_set.meta())
+
+    def test_links(self):
+        links = {
+            'next': 'next_link',
+            'prev': 'prev_link'
+        }
+        api_resource_set = ApiResourceSet()
+        api_resource_set.set_links(links)
+
+        self.assertEqual(links, api_resource_set.links())
+
+    @mock.patch('exonetapi.RequestBuilder.get', return_value='api_response')
+    def test_pagination(self, mock_request_builder):
+        links = {
+            'next': 'https://api.exonet.nl/next_url?filter[unit]=test',
+            'prev': 'https://api.exonet.nl/prev_url?filter[unit]=test',
+            'first': 'https://api.exonet.nl/first/url?filter[unit]=test',
+            'last': 'https://api.exonet.nl/last/url?filter[unit]=test&last=true',
+        }
+        api_resource_set = ApiResourceSet()
+        api_resource_set.set_links(links)
+
+        self.assertEqual('api_response', api_resource_set.next_page())
+        mock_request_builder.assert_called_with('next_url?filter[unit]=test')
+
+        self.assertEqual('api_response', api_resource_set.previous_page())
+        mock_request_builder.assert_called_with('prev_url?filter[unit]=test')
+
+        self.assertEqual('api_response', api_resource_set.first_page())
+        mock_request_builder.assert_called_with('first/url?filter[unit]=test')
+
+        self.assertEqual('api_response', api_resource_set.last_page())
+        mock_request_builder.assert_called_with('last/url?filter[unit]=test&last=true')
+
+        api_resource_set.set_links({'next': None})
+        self.assertEqual(None, api_resource_set.next_page())
+
+    def test_add_resource(self):
+        resource_one = ApiResource('fake', 'abc')
+        resource_two = ApiResource('fake', 'def')
+
+        api_resource_set = ApiResourceSet()
+        api_resource_set.add_resource(resource_one)
+        api_resource_set.add_resource([resource_two])
+
+        self.assertEqual(2, len(api_resource_set))
+
+        for api_resource in api_resource_set:
+            self.assertTrue(api_resource.id() is 'abc' or api_resource.id() is 'def')
+
+        for api_resource in api_resource_set.resources():
+            self.assertTrue(api_resource.id() is 'abc' or api_resource.id() is 'def')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/structures/testResource.py
+++ b/tests/structures/testResource.py
@@ -95,7 +95,7 @@ class testResource(testCase):
             json.dumps(resource.to_json()),
             json.dumps({
                 'type': 'fake',
-                'attributes': { },
+                'attributes': {},
                 'id': 'FakeID',
                 'relationships': {
                     'thing': {
@@ -150,7 +150,6 @@ class testResource(testCase):
         ApiResource({'type': 'fake', 'id': 'FakeID'}).post()
         mock_requestbuilder_init.assert_called_with('fake')
 
-
     def test_reset_changed_attributes(self):
         resource = ApiResource({
             'type': 'fake',
@@ -165,7 +164,6 @@ class testResource(testCase):
 
         resource.reset_changed_attributes()
         self.assertEqual({}, resource.to_json_changed_attributes())
-
 
 
 if __name__ == '__main__':

--- a/tests/structures/testResourceIdentifier.py
+++ b/tests/structures/testResourceIdentifier.py
@@ -91,7 +91,7 @@ class testResourceIdentifier(testCase):
         })
 
         resource.relationship('messages', {
-            'data' : {
+            'data': {
                 'type': 'this',
                 'id': 'that',
             }
@@ -126,7 +126,7 @@ class testResourceIdentifier(testCase):
             json.dumps(resource.to_json()),
             json.dumps({
                 'type': 'fake',
-                'attributes': { },
+                'attributes': {},
                 'id': 'FakeID',
                 'relationships': {
                     'thing': {
@@ -154,6 +154,7 @@ class testResourceIdentifier(testCase):
         ApiResource({'type': 'fake', 'id': 'FakeID'}).get()
         mock_requestbuilder_get.assert_called_with('FakeID')
         mock_requestbuilder_init.assert_called_with('fake')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testRequestBuilder.py
+++ b/tests/testRequestBuilder.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import MagicMock
 from unittest import mock
 
+from requests import Response
+
 from tests.testCase import testCase
 from exonetapi import Client
 from exonetapi.RequestBuilder import RequestBuilder
@@ -12,7 +14,7 @@ from exonetapi.exceptions.ValidationException import ValidationException
 class testRequestBuilder(testCase):
     def setUp(self):
         super().setUp()
-        client = Client('https://test.url')
+        client = Client('https://api.exonet.nl')
         self.request_builder = RequestBuilder('things', client)
 
     def tearDown(self):
@@ -84,11 +86,11 @@ class testRequestBuilder(testCase):
         mock_parser_init.return_value = None
         mock_requests_request.return_value = self.MockResponse('{"data": "getReturnData"}')
 
-        result = self.request_builder.get('testId')
+        result = self.request_builder.get('testIad')
 
         mock_requests_request.assert_called_with(
             'GET',
-            'https://test.url/things/testId',
+            'https://api.exonet.nl/things/testIad',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -118,7 +120,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'POST',
-            'https://test.url/things',
+            'https://api.exonet.nl/things',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -149,7 +151,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'POST',
-            'https://test.url/things/someId/relationships/name',
+            'https://api.exonet.nl/things/someId/relationships/name',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -175,7 +177,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'PATCH',
-            'https://test.url/things/someId',
+            'https://api.exonet.nl/things/someId',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -199,7 +201,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'PATCH',
-            'https://test.url/things/someId/relationships/name',
+            'https://api.exonet.nl/things/someId/relationships/name',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -222,7 +224,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'DELETE',
-            'https://test.url/things/someId',
+            'https://api.exonet.nl/things/someId',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -245,7 +247,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'DELETE',
-            'https://test.url/things/someId/relationships/name',
+            'https://api.exonet.nl/things/someId/relationships/name',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -269,7 +271,7 @@ class testRequestBuilder(testCase):
 
         mock_requests_request.assert_called_with(
             'POST',
-            'https://test.url/things',
+            'https://api.exonet.nl/things',
             headers={
                 'Accept': 'application/vnd.Exonet.v1+json',
                 'Content-Type': 'application/json',
@@ -277,6 +279,39 @@ class testRequestBuilder(testCase):
             },
             json={'data': {'name': 'my_name'}},
             params=None)
+
+    @mock.patch('requests.request')
+    def test_get_recursive(self, mock_requests_request):
+        result_one = Response()
+        result_one.status_code = 200
+        result_one._content = '{"data": ' \
+                              '[{"type": "test", "id": "abc"}], ' \
+                              '"meta": {"total": 2}, ' \
+                              '"links": {"next": "https://api.exonet.nl/next_page"}' \
+                              '}'
+
+        result_two = Response()
+        result_two.status_code = 200
+        result_two._content = '{"data": ' \
+                              '[{"type": "test", "id": "def"}], ' \
+                              '"meta": {"total": 2}, ' \
+                              '"links": {"next": null}' \
+                              '}'
+
+        request_result = [result_one, result_two]
+        mock_requests_request.side_effect = request_result
+
+        self.request_builder.get_recursive()
+        mock_requests_request.assert_any_call('GET', 'https://api.exonet.nl/things',
+                                              headers={'Accept': 'application/vnd.Exonet.v1+json',
+                                                       'Content-Type': 'application/json',
+                                                       'Authorization': 'Bearer None'}, json=None,
+                                              params={})
+        mock_requests_request.assert_any_call('GET', 'https://api.exonet.nl/next_page',
+                                              headers={'Accept': 'application/vnd.Exonet.v1+json',
+                                                       'Content-Type': 'application/json',
+                                                       'Authorization': 'Bearer None'}, json=None,
+                                              params=None)
 
 
 if __name__ == '__main__':

--- a/tests/testRequestBuilder.py
+++ b/tests/testRequestBuilder.py
@@ -33,10 +33,14 @@ class testRequestBuilder(testCase):
     def test_filter(self):
         self.request_builder.filter('firstFilterName', 'firstFilterValue')
         self.request_builder.filter('secondFilterName', 'secondFilterValue')
-        self.assertEqual(self.request_builder._RequestBuilder__query_params['filter[firstFilterName]'],
-                         'firstFilterValue')
-        self.assertEqual(self.request_builder._RequestBuilder__query_params['filter[secondFilterName]'],
-                         'secondFilterValue')
+        self.assertEqual(
+            self.request_builder._RequestBuilder__query_params['filter[firstFilterName]'],
+            'firstFilterValue'
+        )
+        self.assertEqual(
+            self.request_builder._RequestBuilder__query_params['filter[secondFilterName]'],
+            'secondFilterValue'
+        )
 
     def test_page(self):
         self.request_builder.page(3)
@@ -133,7 +137,9 @@ class testRequestBuilder(testCase):
     @mock.patch('requests.request')
     def test_post_relation(self, mock_requests_request, mock_parser_init, mock_parser_parse):
         resource = ApiResource({'type': 'things', 'id': 'someId'})
-        resource.get_json_changed_relationships = MagicMock(return_value={'name': {'data': {'type': 'test', 'id': 1}}})
+        resource.get_json_changed_relationships = MagicMock(
+            return_value={'name': {'data': {'type': 'test', 'id': 1}}}
+        )
 
         mock_parser_parse.return_value = 'parsedReturnValue'
         mock_parser_init.return_value = None
@@ -183,7 +189,9 @@ class testRequestBuilder(testCase):
     @mock.patch('requests.request')
     def test_patch_relation(self, mock_requests_request):
         resource = ApiResource({'type': 'things', 'id': 'someId'})
-        resource.get_json_changed_relationships = MagicMock(return_value={'name': {'data': {'type': 'test', 'id': 1}}})
+        resource.get_json_changed_relationships = MagicMock(
+            return_value={'name': {'data': {'type': 'test', 'id': 1}}}
+        )
 
         mock_requests_request.return_value = self.MockResponse('{"data": "getReturnData"}')
 


### PR DESCRIPTION
```
### Breaking
- When multiple resources are returned from the API, an instance of `ApiResourceSet` is returned instead of a list. This class is traversable so unless the code does specific `list` things or does type checks, no changes are necessary.

### Added
- Add the `total()` method to resource sets to get the total number of resources (and not only the number of resources in the current resource set).
- Add `next_page`, `previous_page`, `first_page` and `last_page` methods to the `ApiResourceSet` for easy loading of paginated resource sets.
- Add a `get_recursive` method to the `RequestBuilder` to get the resource set including recursively the resource sets from the following pages.

### Removed
- The `store` method for creating `POST` requests. (Deprecated since 2.0.0)
```