### PR TITLE
Dependency update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to `exonet-api-python` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## [Unreleased]
-[Compare 3.0.1 - Unreleased](https://github.com/exonet/exonet-api-python/compare/3.0.1...master)
+[Compare 3.0.2 - Unreleased](https://github.com/exonet/exonet-api-python/compare/3.0.2...master)
+
+## [3.0.2](https://github.com/exonet/exonet-api-python/releases/tag/3.0.2) - 2020-08-06
+[Compare 3.0.1 - 3.0.2](https://github.com/exonet/exonet-api-python/compare/3.0.1...3.0.2)
+### Changed
+- Dependencies have been updated. The old `urllib3` version had a vulnerability that is now fixed.
 
 ## [3.0.1](https://github.com/exonet/exonet-api-python/releases/tag/3.0.1) - 2020-10-05
 [Compare 3.0.0 - 3.0.1](https://github.com/exonet/exonet-api-python/compare/3.0.0...3.0.1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ chardet==3.0.4
 coverage==5.3
 idna==2.10
 inflection==0.5.1
-requests==2.24.0
-urllib3==1.25.10
+requests==2.26.0
+urllib3==1.26.6
 pycodestyle==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='exonetapi',
-    version='3.0.1',
+    version='3.0.2',
 
     description='Library to interact with the Exonet API.',
     long_description=long_description,


### PR DESCRIPTION
```
## [3.0.2](https://github.com/exonet/exonet-api-python/releases/tag/3.0.2) - 2020-08-06
[Compare 3.0.1 - 3.0.2](https://github.com/exonet/exonet-api-python/compare/3.0.1...3.0.2)
### Changed
- Dependencies have been updated. The old `urllib3` version had a vulnerability that is now fixed.
```